### PR TITLE
SHOT-4375: Allow tk-alias to use the framework when runnign headless

### DIFF
--- a/python/tk_framework_alias/server/api/__init__.py
+++ b/python/tk_framework_alias/server/api/__init__.py
@@ -114,7 +114,7 @@ if hasattr(os, "add_dll_directory"):
     alias_bin_path = os.environ.get("ALIAS_PLUGIN_CLIENT_ALIAS_EXECPATH")
     if not alias_bin_path:
         raise AliasPythonApiImportError(
-            "Couldn't get Alias bin path: set the environment variable ALIAS_PLUGIN_CLINET_ALIAS_EXECPATH."
+            "Couldn't get Alias bin path: set the environment variable ALIAS_PLUGIN_CLIENT_ALIAS_EXECPATH."
         )
     alias_dll_path = os.path.dirname(alias_bin_path)
     with os.add_dll_directory(alias_dll_path):

--- a/python/tk_framework_alias_utils/startup.py
+++ b/python/tk_framework_alias_utils/startup.py
@@ -433,7 +433,7 @@ def get_plugin_lst(alias_version, python_major_version, python_minor_version, lo
     return lst_file
 
 
-def __ensure_python_c_extension_packages_installed(python_version=None, logger=None):
+def ensure_python_c_extension_packages_installed(python_version=None, logger=None):
     """
     Ensure python C extension packages are unzipped and installed for user.
 
@@ -446,6 +446,10 @@ def __ensure_python_c_extension_packages_installed(python_version=None, logger=N
     :return: True if the packages have beene installed, else False.
     :rtype: bool
     """
+
+    if logger is None:
+        logger = logging.getLogger(__file__)
+        logger.setLevel(logging.DEBUG)
 
     python_versions = environment_utils.get_framework_supported_python_versions()
     if python_version:
@@ -766,7 +770,7 @@ def ensure_plugin_ready(
     # Ensure C extension packages installed for user. Install for all supported Python
     # versions, just in case the python version the framework runs with is different that
     # the current running version.
-    __ensure_python_c_extension_packages_installed(logger=logger)
+    ensure_python_c_extension_packages_installed(logger=logger)
 
     # Get the file path to the .lst file that contains the file path to the Alias Plugin to
     # load at startup with Alias.


### PR DESCRIPTION
* Expose method to allow tk-alias to init the framework when running headless
* Ensure there is a logger object
* Fix typo in log message