### PR TITLE
SHOT-4404: Performance

### DIFF
--- a/python/tk_framework_alias/server/socketio/api_request.py
+++ b/python/tk_framework_alias/server/socketio/api_request.py
@@ -67,16 +67,26 @@ class AliasApiRequestWrapper:
 
         raise NotImplementedError("Subclass must implement")
 
-    @classmethod
-    def _create(cls, data):
+    # ----------------------------------------------------------------------------------------
+    # Public methods
+
+    def validate(self, request_name):
         """
-        Create and return a new object of this type from the given data, if possible.
+        Validate the request against this wrapper.
 
-        :param data: The data to create the object from.
-        :type data: dict
+        :param request_name: The name of the api request.
+        :type request_name: str
+        :raises: AliasApiRequestNotValid if request not valid.
+        """
 
-        :return: An instance of this class.
-        :rtype: AliasApiRequestWrapper
+        raise NotImplementedError("Subclass must implement")
+
+    def execute(self, request_name):
+        """
+        Execute the api request for this wrapper object.
+
+        :param request: The api request name.
+        :type request: str
         """
 
         raise NotImplementedError("Subclass must implement")

--- a/python/tk_framework_alias/server/socketio/api_request.py
+++ b/python/tk_framework_alias/server/socketio/api_request.py
@@ -248,7 +248,6 @@ class AliasApiRequestFunctionWrapper(AliasApiRequestWrapper):
             raise AliasApiRequestNotValid(
                 f"Requested '{request_name}' but should be '{self.func_name}'"
             )
-        return True
 
     def execute(self, request_name):
         """
@@ -366,7 +365,6 @@ class AliasApiRequestPropertyGetterWrapper(AliasApiRequestWrapper):
             raise AliasApiRequestNotValid(
                 f"Requested '{request_name}' but should be '{self.property_name}'"
             )
-        return True
 
     def execute(self, request_name):
         """
@@ -481,7 +479,6 @@ class AliasApiRequestPropertySetterWrapper(AliasApiRequestWrapper):
             raise AliasApiRequestNotValid(
                 f"Requested '{request_name}' but should be '{self.property_name}'"
             )
-        return True
 
     def execute(self, request_name):
         """

--- a/python/tk_framework_alias/server/socketio/api_request.py
+++ b/python/tk_framework_alias/server/socketio/api_request.py
@@ -35,16 +35,9 @@ class AliasApiRequestWrapper:
     def create_wrapper(cls, data):
         """Create and return a new object of this type from the given data, if possible."""
 
-        if isinstance(data, list):
-            return [cls.create_wrapper(item) for item in data]
-
-        if not isinstance(data, dict):
-            return None
-
         for subclass in cls.__subclasses__():
             if subclass.needs_wrapping(data):
                 return subclass(data)
-
         return None
 
     @classmethod
@@ -198,6 +191,8 @@ class AliasApiRequestFunctionWrapper(AliasApiRequestWrapper):
         :rtype: bool
         """
 
+        if not isinstance(value, dict):
+            return False
         return cls.required_data().issubset(set(value.keys()))
 
     # ----------------------------------------------------------------------------------------
@@ -330,6 +325,8 @@ class AliasApiRequestPropertyGetterWrapper(AliasApiRequestWrapper):
         :rtype: bool
         """
 
+        if not isinstance(value, dict):
+            return False
         return cls.required_data() == set(value.keys())
 
     # ----------------------------------------------------------------------------------------
@@ -439,6 +436,8 @@ class AliasApiRequestPropertySetterWrapper(AliasApiRequestWrapper):
         :rtype: bool
         """
 
+        if not isinstance(value, dict):
+            return False
         return cls.required_data() == set(value.keys())
 
     # ----------------------------------------------------------------------------------------

--- a/python/tk_framework_alias/server/socketio/namespaces/server_namespace.py
+++ b/python/tk_framework_alias/server/socketio/namespaces/server_namespace.py
@@ -289,41 +289,15 @@ class AliasServerNamespace(socketio.Namespace):
         if self.client_sid is None or sid != self.client_sid:
             return
 
-        # Execute the Alias API request
+        # Get the request data from the args
         request = args[0] if args else None
+
+        # For multiple requests, create a wrapper to ensure all requests are
+        # invoked in a single Qt event
         if isinstance(request, list):
-            # Handle multiple requests at once. Return a list of results.
-            total_requests = len(request)
-            results = []
-            for i, (event_name, request_data) in enumerate(request, start=1):
-                self._log_message(
-                    None, f"Request ({i} of {total_requests})...", logging.INFO
-                )
-                results.append(self._handle_api_event(event_name, sid, request_data))
-            return results
-        else:
-            # Make a signle request and return the result.
-            return self._handle_api_event(event, sid, request)
+            request = AliasApiRequestWrapper.create_wrapper(request)
 
-    def _handle_api_event(self, event, sid, request):
-        """
-        An Alias API event was triggered by the client.
-
-        Execute the Alias API request from the given data. The event should match an api
-        function (e.g. module function, instance method), and the data contains all the
-        necesasry information to execute the api request.
-
-        :param event: The event corresponding to an api request.
-        :type event: str
-        :param sid: The session id of the client that triggered the event.
-        :type sid: str
-        :param *args: The data list to pass on to the event handler method.
-        :type *args: List[any]
-
-        :return: The return value of the api request.
-        :rtype: any
-        """
-
+        # Execute the request(s)
         self._log_message(None, f"Excuting Alias API request: {request}", logging.INFO)
         result = self._execute_request(event, request)
 


### PR DESCRIPTION
* Currently performance is impacted because Qt QML refreshes after every Alias API request
* With this change, we invoke batch requests in a single Qt event so that QML is only refreshed once after all requests have executed (prevents the UI from updating during multiple API calls)
* Create new class AliasApiRequestListWrapper to handle executing a list of API calls in one Qt event