### PR TITLE
SHOT-4443: Increase server max http buffer

### DIFF
--- a/python/tk_framework_alias/client/socketio/client.py
+++ b/python/tk_framework_alias/client/socketio/client.py
@@ -57,6 +57,7 @@ class AliasSocketIoClient(socketio.Client):
 
         # The connection timeout in seconds
         self.__timeout = kwargs.pop("timeout", 20)
+        kwargs["request_timeout"] = self.__timeout
 
         super().__init__(*args, **kwargs)
 

--- a/python/tk_framework_alias/client/socketio/client_namespace.py
+++ b/python/tk_framework_alias/client/socketio/client_namespace.py
@@ -69,10 +69,10 @@ class AliasClientNamespace(socketio.ClientNamespace):
             # Server exited: No connection could be made because the target machine actively refused it
             self.client.cleanup()
 
-    def on_disconnect(self):
+    def on_disconnect(self, reason=None):
         """Disconnect event."""
 
-        self._log_message("Disconnected from server")
+        self._log_message(f"Disconnected from server. Reason: {reason}")
 
     def on_shutdown(self):
         """Shutdown event."""

--- a/python/tk_framework_alias/server/alias_bridge.py
+++ b/python/tk_framework_alias/server/alias_bridge.py
@@ -79,6 +79,11 @@ class AliasBridge(metaclass=Singleton):
             ping_timeout=60 * 5,
             ping_interval=30,
             json=AliasServerJSON,
+            max_http_buffer_size=1000000
+            * 5,  # 5MB max buffer size for incoming messages
+        )
+        self.__log(
+            f"Server-side max HTTP buffer size: {self.__server_sio.eio.max_http_buffer_size} bytes"
         )
 
         # Create a SocketIO client to handle Alias events triggered in the main thread, which


### PR DESCRIPTION
* Batched Alias API requests may exceed the server-side default max http buffer size of 1MB
* Intermediate fix here is to increase the buffer size and output a more detailed error message to help debug when client drops because message size was too large for server to handle
* Next step (not included in this PR scope): Client will split large requests into smaller chunked requests to avoid exceeding the server side limit