### PR TITLE
SG-30084 Use super() instead of an explicit call to the parent function

### DIFF
--- a/python/tk_framework_alias_utils/log.py
+++ b/python/tk_framework_alias_utils/log.py
@@ -23,9 +23,7 @@ class BootstrapLogHandler(logging.StreamHandler):
         :param record: The record to log.
         """
 
-        # can't use super here because in python 2.6, logging.StreamHandler is
-        # not a new style class.
-        logging.StreamHandler.emit(self, record)
+        super().emit(record)
 
         # always flush to ensure its seen by the js process
         self.flush()


### PR DESCRIPTION
### **Description**

- super() instead of an explicit call to the parent function