### PR TITLE
SG-43665 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,6 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black

--- a/info.yml
+++ b/info.yml
@@ -19,6 +19,7 @@ description: "Plugin and Python API for components that target Autodesk Alias."
 
 # Required minimum versions for this item to run
 requires_core_version: "v0.19.18"
+minimum_python_version: "3.9"
 requires_desktop_version:
 
 # the frameworks this framework requires


### PR DESCRIPTION
Set `minimum_python_version` to `3.9` in `info.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)