### PR TITLE
SG-43665 Revert minimum_python_version to 3.7

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -19,7 +19,7 @@ description: "Plugin and Python API for components that target Autodesk Alias."
 
 # Required minimum versions for this item to run
 requires_core_version: "v0.19.18"
-minimum_python_version: "3.9"
+minimum_python_version: "3.7"
 requires_desktop_version:
 
 # the frameworks this framework requires


### PR DESCRIPTION
## Summary

- Reverts `minimum_python_version` in `info.yml` from `3.9` back to `3.7` - #145

## Context

`tk-framework-alias` bundles its own Python 3.7 for Alias versions 2024.0, 2024.1, 2025.0, and 2025.1, which ship with Python 3.7. The previous change (e76efc8) set `minimum_python_version: 3.9` but did not remove the bundled Python 3.7 assets (`dist/Python/Python37/`, `dist/Alias/python3.7/`).

Setting the minimum to 3.9 would cause those Alias versions to fail to load the framework. Since the bundled 3.7 assets are still present and in active use, the minimum Python version should remain at 3.7 until those Alias versions are fully dropped and the 3.7 assets are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)